### PR TITLE
add discourse document to 'configure slash command' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ However, Slash commands are a bit friendlier to use and allow Slack to auto-comp
 5. Set the URL to wherever you have your bot server hosted. The path to the slash command endpoint is `/slack/receive`, so if your bot is hosted at `https://example.com`, the URL would be `https://example.com/slack/receive`.
 6. You'll need to copy the token provided when you created the slash command and set the `SLACK_SLASH_COMMAND_TOKEN` variable with it for the bot to accept slash commands.
 
+Directions for creating slash commands [can be found in Looker Discourse](https://discourse.looker.com/t/using-lookerbot-for-slack/2302)
+
 ### Data Access
 
 We suggest creating a Looker API user specifically for the Slack bot, and using that user's API credentials. It's worth remembering that _everyone who can talk to your Slack bot has the permissions of this user_. If there's data you don't want people to access via Slack, ensure that user cannot access it using Looker's permissioning mechanisms.


### PR DESCRIPTION
I know this discourse post is already linked in the Features section above, but I think the 'Configure Slash Commands' section is a much more intuitive place to find it when you want to start setting up commands. I propose we have it in both sections.
(A client came on today and did not know that this document existed)

https://discourse.looker.com/t/using-lookerbot-for-slack/2302