### PR TITLE
Use S3 bucket / Azure storage container variables for whether storage system should be used

### DIFF
--- a/lib/bot.coffee
+++ b/lib/bot.coffee
@@ -51,7 +51,7 @@ randomPNGPath = ->
 lookers = lookerConfig.map((looker) ->
 
   # Amazon S3
-  if process.env.AWS_ACCESS_KEY_ID && process.env.AWS_SECRET_ACCESS_KEY
+  if process.env.SLACKBOT_S3_BUCKET
     looker.storeBlob = (blob, success, error) ->
       key = randomPNGPath()
       region = process.env.SLACKBOT_S3_BUCKET_REGION
@@ -77,7 +77,7 @@ lookers = lookerConfig.map((looker) ->
           success("https://#{domain}/#{params.Bucket}/#{key}")
 
   # Azure
-  else if process.env.AZURE_STORAGE_ACCOUNT && process.env.AZURE_STORAGE_ACCESS_KEY
+  else if process.env.SLACKBOT_AZURE_CONTAINER
     looker.storeBlob = (blob, success, error) ->
       key = randomPNGPath()
       container = process.env.SLACKBOT_AZURE_CONTAINER


### PR DESCRIPTION
When using AWS IAM instance profiles (via EC2 metadata service) for accessing AWS resources,
the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environmental variables are not needed. Requiring those variables prevented the `aws-sdk` module from falling through to other methods.

To achieve the same boolean check, use the S3 bucket name / Azure storage container name
as the deciding factor for whether a storage service should be utilized.

Fixes #75.