### PR TITLE
Add `dotenv` to support loading variables from `.env` without `node-foreman`

### DIFF
--- a/lib/bot.coffee
+++ b/lib/bot.coffee
@@ -1,3 +1,5 @@
+require('dotenv').config()
+
 Botkit = require('botkit')
 getUrls = require('get-urls')
 AWS = require('aws-sdk')

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "azure-storage": "~0.10.0",
     "botkit": "0.0.15",
     "coffee-script": "^1.10.0",
+    "dotenv": "^4.0.0",
     "fuzzysearch-js": "^0.2.0",
     "get-urls": "^5.0.0",
     "request": "^2.66.0",


### PR DESCRIPTION
https://github.com/looker/looker-slackbot#running-locally-for-development
discusses using `node-foreman` for local development since it honors `.env`
files. It would be great if `.env` files were always checked, allowing for
alternate deployment mechanisms outside of using actual environmental
variables.