### PR TITLE
add health check

### DIFF
--- a/lib/bot.coffee
+++ b/lib/bot.coffee
@@ -21,6 +21,7 @@ LookQueryRunner = require('./repliers/look_query_runner')
 versionChecker = require('./version_checker')
 ScheduleReceiver = require('./schedule_receiver')
 DataActionReceiver = require('./data_action_receiver')
+HealthCheckReceiver = require('./health_check_receiver')
 
 if process.env.DEV == "true"
   # Allow communicating with Lookers running on localhost with self-signed certificates
@@ -206,6 +207,7 @@ controller.setupWebserver process.env.PORT || 3333, (err, expressWebserver) ->
   controller.createWebhookEndpoints(expressWebserver)
   ScheduleReceiver.listen(expressWebserver, defaultBot, lookers)
   DataActionReceiver.listen(expressWebserver, defaultBot, lookers)
+  HealthCheckReceiver.listen(expressWebserver, defaultBot, lookers)
 
 controller.on 'rtm_reconnect_failed', ->
   throw new Error("Failed to reconnect to the Slack RTM API.")

--- a/lib/health_check_receiver.coffee
+++ b/lib/health_check_receiver.coffee
@@ -1,0 +1,10 @@
+module.exports =
+
+  listen: (server, bot, lookers) ->
+    server.get("/health_check", (req, res) =>
+
+      reply = (json) ->
+        res.setHeader 'Content-Type', 'application/json'
+        res.send JSON.stringify(json)
+      reply {success: true, reason: "Healthy"}
+    )

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "looker-slackbot",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "Slackbot for Looker integration",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Amazon ECS uses Application Load Balancer and Target Groups. The Target Group uses a Health Check endpoint to allow traffic to the backend containers.  This PR adds the health check endpoint. 