### PR TITLE
Fix slash commands never being able to authenticate the user

### DIFF
--- a/lib/bot.coffee
+++ b/lib/bot.coffee
@@ -248,7 +248,7 @@ ensureUserAuthorized = (bot, message, callback, options = {}) ->
   unless options.silent
     context = new ReplyContext(defaultBot, bot, message)
 
-  bot.api.users.info({user: message.user}, (error, response) ->
+  defaultBot.api.users.info({user: message.user}, (error, response) ->
     user = response?.user
     if error || !user
       context?.replyPrivate(


### PR DESCRIPTION
The botkit bot provided for slash commands didn't have the authority to check the user, so they would always fail. The default bot has such authorization.